### PR TITLE
Change return from "false" to "NULL".

### DIFF
--- a/src/std_event_service.cpp
+++ b/src/std_event_service.cpp
@@ -506,7 +506,7 @@ struct event_msg_buff_t {
 
 std_event_msg_buff_t std_client_allocate_msg_buff(unsigned int buffer_space, bool limit_max) {
     event_msg_buff_t *p = new event_msg_buff_t;
-    if (p==NULL) return false;
+    if (p==NULL) return NULL;
 
     try {
         p->buff.resize(buffer_space);


### PR DESCRIPTION
std_client_allocate_msg_buff() returns a std_event_msg_buff_t, so
return NULL pointer instead of boolean literal "false".  While this
change allows building with newer/stricter compilers, it's arguably
not the correct/complete fix. In modern C++, new throws an exeption
and "p" will never be NULL.

    event_msg_buff_t *p = new event_msg_buff_t;
    if (p==NULL) return NULL;

A true fix needs to account for C++ exception handling here (and by
visual inspection, in other functions in this same file).