### PR TITLE
Change macro to static-inline function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-common-utils], [1.5.0+opx1], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-common-utils], [1.5.0+opx2], [ops-dev@lists.openswitch.net])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIRS([m4])
@@ -14,6 +14,7 @@ AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_INSTALL
 LT_INIT([shared])
+AM_MAINTAINER_MODE([enable])
 
 # Checks for libraries.
 AC_CHECK_LIB([dl], [dlopen])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,16 @@
+opx-common-utils (1.5.0+opx2) unstable; urgency=medium
+
+  * Update: Use static-inline instead of macro for IPv4 link-local address
+            checker
+  * Bugfix: Fix debian changelog warnings during build
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 21 Aug 2018 11:00:00 -0800
+
 opx-common-utils (1.5.0+opx1) unstable; urgency=medium
 
-  * Update: Add support for BGP IPv4 Unnumbering
+  * Update: Add API to check IPv4 link-local address for BGP IPv4 Unnumbered
 
- -- Dell EMC <ops-dev@lists.openswitch.net> Mon, 13 Aug 2018 11:00:00 -0800
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 13 Aug 2018 11:00:00 -0800
 
 opx-common-utils (1.5.0) unstable; urgency=medium
 
@@ -12,14 +20,14 @@ opx-common-utils (1.5.0) unstable; urgency=medium
   * Update: Handle system call error codes, rename
   * Update: New Cond var defer_for api
 
- -- Dell EMC <ops-dev@lists.openswitch.net> Tue, 22 May 2018 11:00:00 -0800
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 22 May 2018 11:00:00 -0800
 
 opx-common-utils (1.4.1) unstable; urgency=medium
 
   * Update: Wrapper for Pthread condition var timed wait with Monotonic clock
   * Update: Handling deprecation of readdir_r without effecting the Jessie build
 
- -- Dell EMC <ops-dev@lists.openswitch.net> Tue, 13 Feb 2018 11:00:00 -0800
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 13 Feb 2018 11:00:00 -0800
 
 opx-common-utils (1.4.0) unstable; urgency=medium
 
@@ -33,20 +41,20 @@ opx-common-utils (1.4.0) unstable; urgency=medium
   * Bugfix: xmlGetProp memory leak
   * Bugfix: log levels
 
- -- Dell EMC <ops-dev@lists.openswitch.net> Tue, 05 Dec 2017 11:00:00 -0800
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 05 Dec 2017 11:00:00 -0800
 
 opx-common-utils (1.3.5) unstable; urgency=medium
 
   * Update: Added VXLAN id type
   * Bugfix: Minor fixes
 
- -- Dell EMC <ops-dev@lists.openswitch.net> Fri, 06 Oct 2017 11:00:00 -0800
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 06 Oct 2017 11:00:00 -0800
 
 opx-common-utils (1.3.0) unstable; urgency=medium
 
   * Update: Adding IOV support for reading/writing file descriptors
 
- -- Dell EMC <ops-dev@lists.openswitch.net> Mon, 19 May 2017 13:31:57 -0700
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 19 May 2017 13:31:57 -0700
 
 opx-common-utils (1.0.1) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Description: This package contains general utilities for the Openswitch project.
 
 Package: libopx-common-dev
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},
+Depends: ${misc:Depends},
  libopx-common1 (= ${binary:Version}), libopx-logging-dev (>= 2.1.0)
 Description: This package contains general utilities for the Openswitch project.
 

--- a/inc/opx/std_ip_utils.h
+++ b/inc/opx/std_ip_utils.h
@@ -31,6 +31,7 @@
 //! TODO move the types from db_common here and redefine them in the db-api to use these
 #include "ds_common_types.h"
 #include <netinet/in.h>
+#include <arpa/inet.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,14 +79,18 @@ extern "C" {
         (((((_p_ip_addr)->u.v6_addr [0]) & (0xff)) == (0xfe)) &&              \
          ((((_p_ip_addr)->u.v6_addr [1]) & (0xc0)) == (0x80)))
 
-#define STD_IP_IS_V4_ADDR_LINK_LOCAL(_p_ip_addr)                              \
-    (((htonl(((_p_ip_addr)->u.v4_addr)) & (0xff << 24)) == (0xa9 << 24)) &&   \
-     ((htonl(((_p_ip_addr)->u.v4_addr)) & (0xff << 16)) == (0xfe << 16)))
+/*!
+ * @brief Check if a IPv4 address is the link-local address
+ * @param IPv4 address
+ * @return true/false
+ */
 
-#define STD_IP_IS_ADDR_V4_LINK_LOCAL(_p_ip_addr)                              \
-    (((_p_ip_addr)->af_index == HAL_INET4_FAMILY) ?                           \
-     (STD_IP_IS_V4_ADDR_LINK_LOCAL ((_p_ip_addr))) : 0)
+static inline bool std_is_ip_v4_linklocal_addr(const hal_ip_addr_t *ip_addr) {
 
+    return ((ip_addr->af_index == HAL_INET4_FAMILY) &&
+            ((htonl(ip_addr->u.v4_addr) & ((unsigned long)0xff << 24)) == ((unsigned long)0xa9 << 24)) &&
+            ((htonl(ip_addr->u.v4_addr) & ((unsigned long)0xff << 16)) == ((unsigned long)0xfe << 16)));
+}
 
 
 /*---------------------------------------------------------------*\


### PR DESCRIPTION
Change the API that checks for IPv4 link-local address
from a macro to a static-inline function.

Fixed some warnings that showed up about the formatting
of debian/changelog file during build. The problem was
caused by a line that used two-spaces instead of one.

Signed-off-by: Garrick He <garrick_he@dell.com>