### PR TITLE
opx-common-utils (1.6.0)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,7 @@ src/std_cmd_redir.c         src/std_mac_utils.c   src/std_string_utils.cpp \
 src/std_config_file.cpp     src/std_mergesort.c   src/std_system.c  \
 src/std_config_node.cpp       src/std_mutex_lock.c  src/std_thread_pool.cpp \
 src/std_radical.c     src/std_thread_tools.c \
-src/std_event_service.cpp   src/std_radix.c       src/std_time_tools.c \
+src/std_event_service.cpp   src/std_radix.c       src/std_time_tools.cpp \
 src/std_event_utils.cpp     src/std_rbtree.c      src/std_user_perm.cpp \
 src/std_file_utils.c        src/std_select.c \
 src/std_int_mapping_util.c  src/std_shlib.c \

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-common-utils], [1.5.2+opx2], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-common-utils], [1.6.0], [ops-dev@lists.openswitch.net])
 
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+opx-common-utils (1.6.0) unstable; urgency=medium
+
+  * Update: Fix compiler warnings with GCC-8
+  * Update: Move safe path function to common utils
+  * Update: removing unused api
+  * Update: Add a pthread cancel wrapper and check for errors on pthread_join
+
+ -- Dell EMC <ops-dev@lists.openswitch.net> Wed, 05 Jun 2019 11:00:00 -0800
+
 opx-common-utils (1.5.2+opx2) unstable; urgency=medium
 
   * Update: Copyright information

--- a/inc/opx/std_error_ids.h
+++ b/inc/opx/std_error_ids.h
@@ -96,6 +96,10 @@ enum e_std_error_subsystems {
     e_std_err_BFD=62,
     e_std_err_INFRA_AFS=63,
     e_std_err_FEFD=64,
+    e_std_err_APP_VTEP=65,
+    e_std_err_MCAST_L3=66,
+    e_std_err_NAS_PKT_IO=67,
+    e_std_err_APP_TELEMETRY=68,
 };
 
 enum e_std_error_codes {

--- a/inc/opx/std_file_utils.h
+++ b/inc/opx/std_file_utils.h
@@ -155,6 +155,23 @@ ssize_t std_read_set(int fd, void**data, size_t *data_lens,  size_t set_len, boo
 t_std_error std_netns_fd_open (const char *net_namespace, const char *filename, int flags,
                                int* fd);
 
+/**
+ * @brief Determine if the filename is safe for an operator to access on the
+ *        local filesystem. For security purposes, a file path is considered
+ *        unsafe if any of these conditions is true:
+ *        1) the filename contains a relative path (UP_DIR "..") token
+ *        2) the filename contains invalid chars
+ *
+ * @param[in] filename - the filename (including path) to inspect
+ *
+ * @return true if relative path is safe;
+ *         false otherwise
+ */
+bool
+std_file_uri_safe_local_path(
+        const char *filename);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc/opx/std_ip_utils.h
+++ b/inc/opx/std_ip_utils.h
@@ -79,6 +79,9 @@ extern "C" {
         (((((_p_ip_addr)->u.v6_addr [0]) & (0xff)) == (0xfe)) &&              \
          ((((_p_ip_addr)->u.v6_addr [1]) & (0xc0)) == (0x80)))
 
+#define STD_IP_IS_V4_ADDR_LINK_LOCAL(_p_ip_addr)                              \
+    (((htonl(((_p_ip_addr)->u.v4_addr)) & (0xff << 24)) == (0xa9 << 24)) &&   \
+     ((htonl(((_p_ip_addr)->u.v4_addr)) & (0xff << 16)) == (0xfe << 16)))
 /*!
  * @brief Check if a IPv4 address is the link-local address
  * @param IPv4 address

--- a/inc/opx/std_thread_tools.h
+++ b/inc/opx/std_thread_tools.h
@@ -84,16 +84,34 @@ t_std_error std_thread_create(std_thread_create_param_t * params);
 
 
 /**
+ * @brief Cancel a thread created with std_thread_create()
+ *
+ * @param[in] params structure that was passed to the successful create
+ *                   which started the thread.
+ *
+ * @return On success, returns STD_ERR_OK; on error, returns an error code.
+ */
+t_std_error
+std_thread_cancel(
+        std_thread_create_param_t *params);
+
+
+/**
  * @brief Join with a terminating thread
  * Wait for the thread to exit using data in the std_thread_create_param_t structure.
  * The join takes the create thread parameters as the thread ID is maintained
  * and there may be other fields in the std_thread_create_param_t structure that can be used to shutdown
  * the thread.
  *
- * @param params the structure that was passed to the successful create create which
- *         started the thread.
+ * @param[in,out] params structure that was passed to the successful create
+ *                       which started the thread. if join is successful,
+ *                       contents of the structure are destroyed
+ *
+ * @return On success, returns STD_ERR_OK; on error, returns an error code.
  */
-void std_thread_join(std_thread_create_param_t *params) ;
+t_std_error
+std_thread_join(
+        std_thread_create_param_t *params);
 
 
 /**

--- a/inc/opx/std_time_tools.h
+++ b/inc/opx/std_time_tools.h
@@ -97,6 +97,13 @@ bool std_time_is_expired(uint64_t before, uint64_t time_in_ms);
  */
 void std_time_get_monotonic_clock (size_t interval_in_ms, struct timespec* clock_time);
 
+/**
+ * @Brief - Return current time from epoch in nanoseconds
+ * @return time in nanoseconds as uint64
+ */
+uint64_t std_time_get_current_from_epoch_in_nanoseconds();
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc/opx/std_utils.h
+++ b/inc/opx/std_utils.h
@@ -50,7 +50,14 @@ static inline char *safestrncpy(
     const char *src, /**< [in] source string */
     size_t n         /**< [in] sizeof of destination string */)
 {
+    /* GCC-8 complains about string truncation, but this is intentional */
+    #pragma GCC diagnostic push
+    #if __GNUC__ >= 8 // Only GCC 8 and later
+    #pragma GCC diagnostic ignored "-Wstringop-truncation"
+    #endif
     char *ret = strncpy(dest, src, n);
+    #pragma GCC diagnostic pop
+
     dest[n-1] = 0;
     return ret;
 }

--- a/src/std_radix.c
+++ b/src/std_radix.c
@@ -1490,7 +1490,7 @@ void std_radix_print(std_rt_table *rtt)
     } stack[MAXDEPTH], *sp;
     char prefix[MAXDEPTH];
     int i = MAXDEPTH;
-    char number[4];
+    char number[6];
 
     RDX_DEBUG_START(rtt);
     RDX_DEBUG_END;

--- a/src/std_socket_tools.cpp
+++ b/src/std_socket_tools.cpp
@@ -58,8 +58,8 @@ static void _fill_unix_addr (const std_socket_address_t *in_saddr,
     struct sockaddr_un * unix_addr = (struct sockaddr_un *)out_saddr;
     memset(unix_addr, 0, sizeof(*unix_addr));
     unix_addr->sun_family = AF_UNIX;
-    strncpy(unix_addr->sun_path, in_saddr->address.str,
-            sizeof(unix_addr->sun_path)-1);
+    memcpy(unix_addr->sun_path, in_saddr->address.str,
+           sizeof(unix_addr->sun_path)-1);
     *len = SUN_LEN(unix_addr);
 }
 

--- a/src/std_thread_tools.c
+++ b/src/std_thread_tools.c
@@ -117,7 +117,59 @@ t_std_error std_thread_create(std_thread_create_param_t * params) {
     return rc;
 }
 
-void std_thread_join(std_thread_create_param_t *params) {
-    pthread_join(*((pthread_t*)(params->thread_id)),NULL);
+t_std_error
+std_thread_cancel(
+        std_thread_create_param_t *params)
+{
+    int rc = 0;
+
+    if ((NULL == params) || (NULL==params->thread_id)) {
+        /* invalid parameters */
+        EV_LOGGING(COM, ERR, "THR",
+                "Invalid input params %p",
+                params);
+        return STD_ERR_MK(e_std_err_COM, e_std_err_code_PARAM, 0);
+    }
+
+    rc = pthread_cancel(*((pthread_t*)(params->thread_id)));
+    if (0 != rc) {
+        /* cancel failed */
+        EV_LOGGING(COM, ERR, "THR",
+                "Error %d, failed to cancel thread:%s func:%p",
+                rc, params->name, params->thread_function);
+        return STD_ERR_MK(e_std_err_COM, e_std_err_code_FAIL, rc);
+    }
+
+    /* cancel successful */
+    return STD_ERR_OK;
+}
+
+t_std_error
+std_thread_join(
+        std_thread_create_param_t *params)
+{
+    int rc = 0;
+
+    if ((NULL == params) || (NULL==params->thread_id)) {
+        /* invalid parameters */
+        EV_LOGGING(COM, ERR, "THR",
+                "Invalid input params %p",
+                params);
+        return STD_ERR_MK(e_std_err_COM, e_std_err_code_PARAM, 0);
+    }
+
+    rc = pthread_join(*((pthread_t*)(params->thread_id)),NULL);
+    if (0 != rc) {
+        /* join failed */
+        EV_LOGGING(COM, ERR, "THR",
+                "Error %d, failed to join thread:%s func:%p",
+                rc, params->name, params->thread_function);
+        return STD_ERR_MK(e_std_err_COM, e_std_err_code_FAIL, rc);
+    }
+
+    /* join successful, destory the params */
+    std_thread_destroy_struct(params);
+
+    return STD_ERR_OK;
 }
 

--- a/src/std_time_tools.c
+++ b/src/std_time_tools.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019  Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/std_time_tools.cpp
+++ b/src/std_time_tools.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/std_time_tools.cpp
+++ b/src/std_time_tools.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * filename: std_time_tools.cpp
+ */
+#include <std_time_tools.h>
+#include <std_error_codes.h>
+#include <time.h>
+#include <chrono>
+#include <unistd.h>
+
+
+#ifdef CLOCK_MONOTONIC_RAW
+#define _CLOCK_ID CLOCK_MONOTONIC_RAW
+#else
+#define _CLOCK_ID CLOCK_MONOTONIC
+#endif
+
+t_std_error std_usleep(unsigned int usecs) {
+    register int rc = 0;
+    register int fail_cnt = 5;
+    while (fail_cnt-->0) {
+        rc = usleep(usecs);
+        if (rc==-1 && errno!=EINTR) {
+            return STD_ERR_FROM_ERRNO(e_std_err_COM,e_std_err_code_FAIL);
+        }
+        if (rc==0) break;
+    }
+    return rc == 0 ? STD_ERR_OK : STD_ERR_FROM_ERRNO(e_std_err_COM,
+                                                        e_std_err_code_FAIL);
+}
+
+
+uint64_t std_get_uptime(t_std_error *err) {
+    struct timespec now;
+    /*really just want clock monotonic but looks like an annoying behaviuor
+    of changing based on ntp adjustments.. so use raw*/
+    uint64_t val = 0;
+
+    int rc = clock_gettime(_CLOCK_ID,&now);
+    if (err!=NULL) {
+        *err = rc==0 ? STD_ERR_OK : STD_ERR_FROM_ERRNO(e_std_err_COM,
+                                    e_std_err_code_FAIL);
+    }
+    if (rc==0) {
+        val = now.tv_nsec/1000;
+        val += ((uint64_t)now.tv_sec)*1000000;
+    }
+
+    return val;
+}
+
+bool std_time_is_expired(uint64_t before, uint64_t time_in_ms) {
+    uint64_t now = std_get_uptime(NULL);
+    return (now - before) >= time_in_ms;
+}
+
+#define MILLISEC_IN_A_SEC (1000)
+#define NANOSEC_IN_A_SEC (1000 * 1000 * 1000)
+
+
+void std_time_get_monotonic_clock (size_t interval_in_ms, struct timespec* clock_time)
+{
+    clock_gettime(CLOCK_MONOTONIC, clock_time);
+    if (interval_in_ms == 0) return;
+
+    /* Add the sub-second fraction of interval to the nano-secs in time spec */
+    clock_time->tv_nsec += MILLI_TO_NANO (interval_in_ms % MILLISEC_IN_A_SEC);
+    /* Did we go over a second */
+    uint_t overflow = NANOSEC_TO_SEC (clock_time->tv_nsec);
+    if (overflow > 0) {
+        clock_time->tv_nsec %= NANOSEC_IN_A_SEC;
+    }
+
+    clock_time->tv_sec += (MILLISEC_TO_SEC (interval_in_ms) + overflow);
+}
+
+uint64_t std_time_get_current_from_epoch_in_nanoseconds(){
+    using namespace std::chrono;
+    nanoseconds ns = duration_cast<nanoseconds>(system_clock::now().time_since_epoch());
+    return ns.count();
+}


### PR DESCRIPTION
* Update: Fix compiler warnings with GCC-8
  * Update: Move safe path function to common utils
  * Update: removing unused api
  * Update: Add a pthread cancel wrapper and check for errors on pthread_join

Signed-off-by: Rakesh Datta <rakesh.datta@dell.com>